### PR TITLE
Dedupe RPATH entries

### DIFF
--- a/src/ld/HeaderAndLoadCommands.hpp
+++ b/src/ld/HeaderAndLoadCommands.hpp
@@ -470,7 +470,14 @@ uint64_t HeaderAndLoadCommandsAtom<A>::size() const
 	
 	if ( _hasRPathLoadCommands ) {
 		const std::vector<const char*>& rpaths = _options.rpaths();
+		std::set<std::string> seen;
+
 		for (std::vector<const char*>::const_iterator it = rpaths.begin(); it != rpaths.end(); ++it) {
+			std::string it_(*it);
+			if (seen.find(it_) != std::end(seen))
+				continue;
+			seen.insert(it_);
+
 			sz += alignedSize(sizeof(macho_rpath_command<P>) + strlen(*it) + 1);
 		}
 	}
@@ -579,8 +586,18 @@ uint32_t HeaderAndLoadCommandsAtom<A>::commandsCount() const
 	
 	count += _dylibLoadCommmandsCount;
 
-	count += _options.rpaths().size();
-	
+	{
+		const std::vector<const char*>& rpaths = _options.rpaths();
+		std::set<std::string> seen;
+		for (std::vector<const char*>::const_iterator it = rpaths.begin(); it != rpaths.end(); ++it) {
+			std::string it_(*it);
+			if (seen.find(it_) != std::end(seen))
+				continue;
+			seen.insert(it_);
+			++count;
+		}
+	}
+
 	if ( _hasSubFrameworkLoadCommand )
 		++count;
 	
@@ -1764,7 +1781,15 @@ void HeaderAndLoadCommandsAtom<A>::copyRawContent(uint8_t buffer[]) const
 
 	if ( _hasRPathLoadCommands ) {
 		const std::vector<const char*>& rpaths = _options.rpaths();
+		std::set<std::string> seen;
+
 		for (std::vector<const char*>::const_iterator it = rpaths.begin(); it != rpaths.end(); ++it) {
+			std::string it_(*it);
+			if (seen.find(it_) != std::end(seen))
+				continue;
+
+			seen.insert(it_);
+
 			p = this->copyRPathLoadCommand(p, *it);
 		}
 	}


### PR DESCRIPTION
This is required for MacOS 15.4 and above, which rejects loading libraries with duplicate RPATH entries.

I'm not familiar with this codebase, and only reasonably familiar with CPP, so this patch does the deduplicating in three places: when calculating the number of load commands, when calculating the 'size' of the `HeaderAndLoadCommandsAtom`, and also when writing the RPATH load commands. I suppose this could all be done in one place, but I'm not sure what CPP wizardry is going on here.

This fixed: https://github.com/NixOS/nixpkgs/issues/395169